### PR TITLE
добавить в классе InMemoryHistoryManager реализацию нового вложенного…

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,13 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="830ab6ca-d4df-494b-a93f-ee04c930bdcd" name="Changes" comment="подправить code style">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/controllers/InMemoryHistoryManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/InMemoryHistoryManager.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/controllers/InMemoryTaskManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/InMemoryTaskManager.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/controllers/Node.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/Node.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/model/Epic.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/model/Epic.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/model/Subtask.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/model/Subtask.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/model/Task.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/model/Task.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -47,7 +53,7 @@
     "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "Application.Main.executor": "Run",
     "Downloaded.Files.Path.Enabled": "true",
-    "JUnit.All in java-kanban.executor": "Debug",
+    "JUnit.All in java-kanban.executor": "Coverage",
     "JUnit.InMemoryTaskManagerTest.EpicShouldNotAddToSubtask.executor": "Run",
     "JUnit.InMemoryTaskManagerTest.addNewTask.executor": "Run",
     "JUnit.InMemoryTaskManagerTest.epicSubtaskIDsListDoNotContainSubtaskIDAfterRemove.executor": "Run",
@@ -237,7 +243,23 @@
       <option name="project" value="LOCAL" />
       <updated>1745271371892</updated>
     </task>
-    <option name="localTasksCounter" value="10" />
+    <task id="LOCAL-00010" summary="подправить code style">
+      <option name="closed" value="true" />
+      <created>1745271492051</created>
+      <option name="number" value="00010" />
+      <option name="presentableId" value="LOCAL-00010" />
+      <option name="project" value="LOCAL" />
+      <updated>1745271492051</updated>
+    </task>
+    <task id="LOCAL-00011" summary="подправить code style">
+      <option name="closed" value="true" />
+      <created>1745271717364</created>
+      <option name="number" value="00011" />
+      <option name="presentableId" value="LOCAL-00011" />
+      <option name="project" value="LOCAL" />
+      <updated>1745271717364</updated>
+    </task>
+    <option name="localTasksCounter" value="12" />
     <servers />
   </component>
   <component name="Vcs.Log.Tabs.Properties">
@@ -274,6 +296,6 @@
     </breakpoint-manager>
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
-    <SUITE FILE_PATH="coverage/java_kanban$All_in_java_kanban.ic" NAME="All in java-kanban Coverage Results" MODIFIED="1745268164102" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
+    <SUITE FILE_PATH="coverage/java_kanban$All_in_java_kanban.ic" NAME="All in java-kanban Coverage Results" MODIFIED="1745362842962" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="830ab6ca-d4df-494b-a93f-ee04c930bdcd" name="Changes" comment="подправить code style" />
+    <list default="true" id="830ab6ca-d4df-494b-a93f-ee04c930bdcd" name="Changes" comment="подправить code style">
+      <change beforePath="$PROJECT_DIR$/src/controllers/Node.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/Node.java" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -45,7 +47,7 @@
     "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "Application.Main.executor": "Run",
     "Downloaded.Files.Path.Enabled": "true",
-    "JUnit.All in java-kanban.executor": "Coverage",
+    "JUnit.All in java-kanban.executor": "Debug",
     "JUnit.InMemoryTaskManagerTest.EpicShouldNotAddToSubtask.executor": "Run",
     "JUnit.InMemoryTaskManagerTest.addNewTask.executor": "Run",
     "JUnit.InMemoryTaskManagerTest.epicSubtaskIDsListDoNotContainSubtaskIDAfterRemove.executor": "Run",
@@ -227,7 +229,15 @@
       <option name="project" value="LOCAL" />
       <updated>1745270999823</updated>
     </task>
-    <option name="localTasksCounter" value="9" />
+    <task id="LOCAL-00009" summary="подправить code style">
+      <option name="closed" value="true" />
+      <created>1745271371892</created>
+      <option name="number" value="00009" />
+      <option name="presentableId" value="LOCAL-00009" />
+      <option name="project" value="LOCAL" />
+      <updated>1745271371892</updated>
+    </task>
+    <option name="localTasksCounter" value="10" />
     <servers />
   </component>
   <component name="Vcs.Log.Tabs.Properties">

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,17 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="830ab6ca-d4df-494b-a93f-ee04c930bdcd" name="Changes" comment=" fix:  InMemoryHistoryManager исправлен метод copyTask()&#10; fix:  InMemoryTaskManager добавлены проверки на null в методах getTaskById" />
+    <list default="true" id="830ab6ca-d4df-494b-a93f-ee04c930bdcd" name="Changes" comment="d">
+      <change afterPath="$PROJECT_DIR$/src/controllers/Node.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/Main.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/Main.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/controllers/HistoryManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/HistoryManager.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/controllers/InMemoryHistoryManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/InMemoryHistoryManager.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/controllers/InMemoryTaskManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/InMemoryTaskManager.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/controllers/TaskManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/TaskManager.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/controllers/InMemoryTaskManagerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/test/controllers/InMemoryTaskManagerTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/controllers/ManagersTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/test/controllers/ManagersTest.java" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -15,8 +25,8 @@
       <list>
         <option value="Enum" />
         <option value="Interface" />
-        <option value="Class" />
         <option value="JUnit5 Test Class" />
+        <option value="Class" />
       </list>
     </option>
   </component>
@@ -45,7 +55,18 @@
     "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "Application.Main.executor": "Run",
     "Downloaded.Files.Path.Enabled": "true",
-    "JUnit.All in java-kanban.executor": "Run",
+    "JUnit.All in java-kanban.executor": "Coverage",
+    "JUnit.InMemoryTaskManagerTest.EpicShouldNotAddToSubtask.executor": "Run",
+    "JUnit.InMemoryTaskManagerTest.addNewTask.executor": "Run",
+    "JUnit.InMemoryTaskManagerTest.epicSubtaskIDsListDoNotContainSubtaskIDAfterRemove.executor": "Run",
+    "JUnit.InMemoryTaskManagerTest.executor": "Run",
+    "JUnit.InMemoryTaskManagerTest.historyShouldKeepPreviousTaskVersionAfterUpdate.executor": "Run",
+    "JUnit.InMemoryTaskManagerTest.linkedListHistoryRemoveTests.executor": "Run",
+    "JUnit.InMemoryTaskManagerTest.linkedListHistoryTests.executor": "Run",
+    "JUnit.InMemoryTaskManagerTest.removeAllTasks.executor": "Run",
+    "JUnit.InMemoryTaskManagerTest.removeTaskById.executor": "Run",
+    "JUnit.InMemoryTaskManagerTest.updateAndGetHistory.executor": "Run",
+    "JUnit.InMemoryTaskManagerTest.updateTaskDoNotInfluenceToHistory.executor": "Run",
     "Repository.Attach.Annotations": "false",
     "Repository.Attach.JavaDocs": "false",
     "Repository.Attach.Sources": "false",
@@ -53,7 +74,7 @@
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
-    "git-widget-placeholder": "main",
+    "git-widget-placeholder": "sprint__6-solution",
     "kotlin-language-version-configured": "true"
   }
 }]]></component>
@@ -61,12 +82,22 @@
     <key name="CreateTestDialog.Recents.Supers">
       <recent name="" />
     </key>
+    <key name="MoveClassesOrPackagesDialog.RECENTS_KEY">
+      <recent name="model" />
+    </key>
     <key name="CreateTestDialog.RecentsKey">
       <recent name="controllers" />
       <recent name="model" />
     </key>
   </component>
-  <component name="RunManager">
+  <component name="RunManager" selected="JUnit.All in java-kanban">
+    <configuration name="Main" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
+      <option name="MAIN_CLASS_NAME" value="Main" />
+      <module name="java-kanban" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
     <configuration name="All in java-kanban" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
       <module name="java-kanban" />
       <option name="PACKAGE_NAME" value="" />
@@ -75,9 +106,61 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
+    <configuration name="InMemoryTaskManagerTest.epicSubtaskIDsListDoNotContainSubtaskIDAfterRemove" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <module name="java-kanban" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="model.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <option name="PACKAGE_NAME" value="controllers" />
+      <option name="MAIN_CLASS_NAME" value="controllers.InMemoryTaskManagerTest" />
+      <option name="METHOD_NAME" value="epicSubtaskIDsListDoNotContainSubtaskIDAfterRemove" />
+      <option name="TEST_OBJECT" value="method" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="InMemoryTaskManagerTest.linkedListHistoryRemoveTests" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <module name="java-kanban" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="model.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <option name="PACKAGE_NAME" value="controllers" />
+      <option name="MAIN_CLASS_NAME" value="controllers.InMemoryTaskManagerTest" />
+      <option name="METHOD_NAME" value="linkedListHistoryRemoveTests" />
+      <option name="TEST_OBJECT" value="method" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="InMemoryTaskManagerTest.linkedListHistoryTests" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <module name="java-kanban" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="model.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <option name="PACKAGE_NAME" value="controllers" />
+      <option name="MAIN_CLASS_NAME" value="controllers.InMemoryTaskManagerTest" />
+      <option name="METHOD_NAME" value="linkedListHistoryTests" />
+      <option name="TEST_OBJECT" value="method" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
     <recent_temporary>
       <list>
         <item itemvalue="JUnit.All in java-kanban" />
+        <item itemvalue="Application.Main" />
+        <item itemvalue="JUnit.InMemoryTaskManagerTest.epicSubtaskIDsListDoNotContainSubtaskIDAfterRemove" />
+        <item itemvalue="JUnit.InMemoryTaskManagerTest.linkedListHistoryRemoveTests" />
+        <item itemvalue="JUnit.InMemoryTaskManagerTest.linkedListHistoryTests" />
       </list>
     </recent_temporary>
   </component>
@@ -130,7 +213,15 @@
       <option name="project" value="LOCAL" />
       <updated>1743512358086</updated>
     </task>
-    <option name="localTasksCounter" value="6" />
+    <task id="LOCAL-00006" summary="d">
+      <option name="closed" value="true" />
+      <created>1744983002686</created>
+      <option name="number" value="00006" />
+      <option name="presentableId" value="LOCAL-00006" />
+      <option name="project" value="LOCAL" />
+      <updated>1744983002686</updated>
+    </task>
+    <option name="localTasksCounter" value="7" />
     <servers />
   </component>
   <component name="Vcs.Log.Tabs.Properties">
@@ -151,7 +242,8 @@
     <MESSAGE value="&#10;refactor:  TaskManager разделен на интерфейс и реализацию  &#10;feat: добавлена историю просмотра задач (InMemoryHistoryManager)  &#10;test: добавлены тесты для истории, добавления,  обновления задач и статусов." />
     <MESSAGE value="feat: добавлено консольное обновление задач + вызов истории (Main)" />
     <MESSAGE value=" fix:  InMemoryHistoryManager исправлен метод copyTask()&#10; fix:  InMemoryTaskManager добавлены проверки на null в методах getTaskById" />
-    <option name="LAST_COMMIT_MESSAGE" value=" fix:  InMemoryHistoryManager исправлен метод copyTask()&#10; fix:  InMemoryTaskManager добавлены проверки на null в методах getTaskById" />
+    <MESSAGE value="d" />
+    <option name="LAST_COMMIT_MESSAGE" value="d" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>
@@ -164,6 +256,6 @@
     </breakpoint-manager>
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
-    <SUITE FILE_PATH="coverage/java_kanban$All_in_java_kanban.ic" NAME="All in java-kanban Coverage Results" MODIFIED="1743455438379" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
+    <SUITE FILE_PATH="coverage/java_kanban$All_in_java_kanban.ic" NAME="All in java-kanban Coverage Results" MODIFIED="1745268164102" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="830ab6ca-d4df-494b-a93f-ee04c930bdcd" name="Changes" comment="&#10;добавить в классе InMemoryHistoryManager реализацию нового вложенного класса  HistoryManagerLinkList&#10;&#10;изменить метод хранения истории задач с помощью двусвязного списка и HashMap&#10;&#10;убрать ограничения в количестве сохраняемых задач в истории.&#10;&#10;реализовать метод linkLast добавляющий задачу в конец списка.&#10;&#10;реализовать метод removeNode  удаляющий узел из двусязного списка задач.&#10;&#10;переименовать метод updateHistory в метод  add  и переделать логику согласно ТЗ_6.&#10;&#10;избавиться от повторных просмотров в истории.&#10;&#10;добавить метод remove для удаления задач из истории по ID &#10;&#10;добавить новый Node - отвечающий за узлы в двусвязном списке.&#10;&#10;обновить unit-тесты.&#10;&#10;реализовать пользовательский сценарий в Main. &#10;&#10;добавить Javadoc в  InMemoryHistoryManager">
-      <change beforePath="$PROJECT_DIR$/src/controllers/InMemoryTaskManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/InMemoryTaskManager.java" afterDir="false" />
-    </list>
+    <list default="true" id="830ab6ca-d4df-494b-a93f-ee04c930bdcd" name="Changes" comment="подправить code style" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -82,7 +80,7 @@
       <recent name="model" />
     </key>
   </component>
-  <component name="RunManager" selected="JUnit.All in java-kanban">
+  <component name="RunManager" selected="Application.Main">
     <configuration name="Main" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="Main" />
       <module name="java-kanban" />
@@ -148,8 +146,8 @@
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="JUnit.All in java-kanban" />
         <item itemvalue="Application.Main" />
+        <item itemvalue="JUnit.All in java-kanban" />
         <item itemvalue="JUnit.InMemoryTaskManagerTest.epicSubtaskIDsListDoNotContainSubtaskIDAfterRemove" />
         <item itemvalue="JUnit.InMemoryTaskManagerTest.linkedListHistoryRemoveTests" />
         <item itemvalue="JUnit.InMemoryTaskManagerTest.linkedListHistoryTests" />
@@ -221,7 +219,15 @@
       <option name="project" value="LOCAL" />
       <updated>1745269898085</updated>
     </task>
-    <option name="localTasksCounter" value="8" />
+    <task id="LOCAL-00008" summary="подправить code style">
+      <option name="closed" value="true" />
+      <created>1745270999823</created>
+      <option name="number" value="00008" />
+      <option name="presentableId" value="LOCAL-00008" />
+      <option name="project" value="LOCAL" />
+      <updated>1745270999823</updated>
+    </task>
+    <option name="localTasksCounter" value="9" />
     <servers />
   </component>
   <component name="Vcs.Log.Tabs.Properties">
@@ -244,7 +250,8 @@
     <MESSAGE value=" fix:  InMemoryHistoryManager исправлен метод copyTask()&#10; fix:  InMemoryTaskManager добавлены проверки на null в методах getTaskById" />
     <MESSAGE value="d" />
     <MESSAGE value="&#10;добавить в классе InMemoryHistoryManager реализацию нового вложенного класса  HistoryManagerLinkList&#10;&#10;изменить метод хранения истории задач с помощью двусвязного списка и HashMap&#10;&#10;убрать ограничения в количестве сохраняемых задач в истории.&#10;&#10;реализовать метод linkLast добавляющий задачу в конец списка.&#10;&#10;реализовать метод removeNode  удаляющий узел из двусязного списка задач.&#10;&#10;переименовать метод updateHistory в метод  add  и переделать логику согласно ТЗ_6.&#10;&#10;избавиться от повторных просмотров в истории.&#10;&#10;добавить метод remove для удаления задач из истории по ID &#10;&#10;добавить новый Node - отвечающий за узлы в двусвязном списке.&#10;&#10;обновить unit-тесты.&#10;&#10;реализовать пользовательский сценарий в Main. &#10;&#10;добавить Javadoc в  InMemoryHistoryManager" />
-    <option name="LAST_COMMIT_MESSAGE" value="&#10;добавить в классе InMemoryHistoryManager реализацию нового вложенного класса  HistoryManagerLinkList&#10;&#10;изменить метод хранения истории задач с помощью двусвязного списка и HashMap&#10;&#10;убрать ограничения в количестве сохраняемых задач в истории.&#10;&#10;реализовать метод linkLast добавляющий задачу в конец списка.&#10;&#10;реализовать метод removeNode  удаляющий узел из двусязного списка задач.&#10;&#10;переименовать метод updateHistory в метод  add  и переделать логику согласно ТЗ_6.&#10;&#10;избавиться от повторных просмотров в истории.&#10;&#10;добавить метод remove для удаления задач из истории по ID &#10;&#10;добавить новый Node - отвечающий за узлы в двусвязном списке.&#10;&#10;обновить unit-тесты.&#10;&#10;реализовать пользовательский сценарий в Main. &#10;&#10;добавить Javadoc в  InMemoryHistoryManager" />
+    <MESSAGE value="подправить code style" />
+    <option name="LAST_COMMIT_MESSAGE" value="подправить code style" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,14 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="830ab6ca-d4df-494b-a93f-ee04c930bdcd" name="Changes" comment="подправить code style">
+    <list default="true" id="830ab6ca-d4df-494b-a93f-ee04c930bdcd" name="Changes" comment="Внести изменения, согласно комментариям ревью.&#10;&#10;Реализовать удаление задач из истории при вызове метода removeAllTasks.&#10;&#10;Модифицировать class Node: удалить типизацию, сделать сеттеры protected.&#10;&#10;Модифицировать class InMemoryHistoryManager: удалить поле  size, удалить класс class HistoryManagerLinkList, добавить методы в InMemoryHistoryManager.&#10;&#10;Добавить конструктор для глубокого копирования задач в классы Task, Subtask, Epic. &#10;&#10;Модифицировать методы get...ById, возвращают копию задачи.">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/controllers/InMemoryHistoryManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/InMemoryHistoryManager.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/controllers/InMemoryTaskManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/InMemoryTaskManager.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/controllers/Node.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/Node.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/model/Epic.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/model/Epic.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/model/Subtask.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/model/Subtask.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/model/Task.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/model/Task.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -259,7 +255,15 @@
       <option name="project" value="LOCAL" />
       <updated>1745271717364</updated>
     </task>
-    <option name="localTasksCounter" value="12" />
+    <task id="LOCAL-00012" summary="Внести изменения, согласно комментариям ревью.&#10;&#10;Реализовать удаление задач из истории при вызове метода removeAllTasks.&#10;&#10;Модифицировать class Node: удалить типизацию, сделать сеттеры protected.&#10;&#10;Модифицировать class InMemoryHistoryManager: удалить поле  size, удалить класс class HistoryManagerLinkList, добавить методы в InMemoryHistoryManager.&#10;&#10;Добавить конструктор для глубокого копирования задач в классы Task, Subtask, Epic. &#10;&#10;Модифицировать методы get...ById, возвращают копию задачи.">
+      <option name="closed" value="true" />
+      <created>1745366668666</created>
+      <option name="number" value="00012" />
+      <option name="presentableId" value="LOCAL-00012" />
+      <option name="project" value="LOCAL" />
+      <updated>1745366668666</updated>
+    </task>
+    <option name="localTasksCounter" value="13" />
     <servers />
   </component>
   <component name="Vcs.Log.Tabs.Properties">
@@ -283,7 +287,8 @@
     <MESSAGE value="d" />
     <MESSAGE value="&#10;добавить в классе InMemoryHistoryManager реализацию нового вложенного класса  HistoryManagerLinkList&#10;&#10;изменить метод хранения истории задач с помощью двусвязного списка и HashMap&#10;&#10;убрать ограничения в количестве сохраняемых задач в истории.&#10;&#10;реализовать метод linkLast добавляющий задачу в конец списка.&#10;&#10;реализовать метод removeNode  удаляющий узел из двусязного списка задач.&#10;&#10;переименовать метод updateHistory в метод  add  и переделать логику согласно ТЗ_6.&#10;&#10;избавиться от повторных просмотров в истории.&#10;&#10;добавить метод remove для удаления задач из истории по ID &#10;&#10;добавить новый Node - отвечающий за узлы в двусвязном списке.&#10;&#10;обновить unit-тесты.&#10;&#10;реализовать пользовательский сценарий в Main. &#10;&#10;добавить Javadoc в  InMemoryHistoryManager" />
     <MESSAGE value="подправить code style" />
-    <option name="LAST_COMMIT_MESSAGE" value="подправить code style" />
+    <MESSAGE value="Внести изменения, согласно комментариям ревью.&#10;&#10;Реализовать удаление задач из истории при вызове метода removeAllTasks.&#10;&#10;Модифицировать class Node: удалить типизацию, сделать сеттеры protected.&#10;&#10;Модифицировать class InMemoryHistoryManager: удалить поле  size, удалить класс class HistoryManagerLinkList, добавить методы в InMemoryHistoryManager.&#10;&#10;Добавить конструктор для глубокого копирования задач в классы Task, Subtask, Epic. &#10;&#10;Модифицировать методы get...ById, возвращают копию задачи." />
+    <option name="LAST_COMMIT_MESSAGE" value="Внести изменения, согласно комментариям ревью.&#10;&#10;Реализовать удаление задач из истории при вызове метода removeAllTasks.&#10;&#10;Модифицировать class Node: удалить типизацию, сделать сеттеры protected.&#10;&#10;Модифицировать class InMemoryHistoryManager: удалить поле  size, удалить класс class HistoryManagerLinkList, добавить методы в InMemoryHistoryManager.&#10;&#10;Добавить конструктор для глубокого копирования задач в классы Task, Subtask, Epic. &#10;&#10;Модифицировать методы get...ById, возвращают копию задачи." />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,16 +4,8 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="830ab6ca-d4df-494b-a93f-ee04c930bdcd" name="Changes" comment="d">
-      <change afterPath="$PROJECT_DIR$/src/controllers/Node.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/Main.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/Main.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/controllers/HistoryManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/HistoryManager.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/controllers/InMemoryHistoryManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/InMemoryHistoryManager.java" afterDir="false" />
+    <list default="true" id="830ab6ca-d4df-494b-a93f-ee04c930bdcd" name="Changes" comment="&#10;добавить в классе InMemoryHistoryManager реализацию нового вложенного класса  HistoryManagerLinkList&#10;&#10;изменить метод хранения истории задач с помощью двусвязного списка и HashMap&#10;&#10;убрать ограничения в количестве сохраняемых задач в истории.&#10;&#10;реализовать метод linkLast добавляющий задачу в конец списка.&#10;&#10;реализовать метод removeNode  удаляющий узел из двусязного списка задач.&#10;&#10;переименовать метод updateHistory в метод  add  и переделать логику согласно ТЗ_6.&#10;&#10;избавиться от повторных просмотров в истории.&#10;&#10;добавить метод remove для удаления задач из истории по ID &#10;&#10;добавить новый Node - отвечающий за узлы в двусвязном списке.&#10;&#10;обновить unit-тесты.&#10;&#10;реализовать пользовательский сценарий в Main. &#10;&#10;добавить Javadoc в  InMemoryHistoryManager">
       <change beforePath="$PROJECT_DIR$/src/controllers/InMemoryTaskManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/InMemoryTaskManager.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/controllers/TaskManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/controllers/TaskManager.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/test/controllers/InMemoryTaskManagerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/test/controllers/InMemoryTaskManagerTest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/test/controllers/ManagersTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/test/controllers/ManagersTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -221,7 +213,15 @@
       <option name="project" value="LOCAL" />
       <updated>1744983002686</updated>
     </task>
-    <option name="localTasksCounter" value="7" />
+    <task id="LOCAL-00007" summary="&#10;добавить в классе InMemoryHistoryManager реализацию нового вложенного класса  HistoryManagerLinkList&#10;&#10;изменить метод хранения истории задач с помощью двусвязного списка и HashMap&#10;&#10;убрать ограничения в количестве сохраняемых задач в истории.&#10;&#10;реализовать метод linkLast добавляющий задачу в конец списка.&#10;&#10;реализовать метод removeNode  удаляющий узел из двусязного списка задач.&#10;&#10;переименовать метод updateHistory в метод  add  и переделать логику согласно ТЗ_6.&#10;&#10;избавиться от повторных просмотров в истории.&#10;&#10;добавить метод remove для удаления задач из истории по ID &#10;&#10;добавить новый Node - отвечающий за узлы в двусвязном списке.&#10;&#10;обновить unit-тесты.&#10;&#10;реализовать пользовательский сценарий в Main. &#10;&#10;добавить Javadoc в  InMemoryHistoryManager">
+      <option name="closed" value="true" />
+      <created>1745269898085</created>
+      <option name="number" value="00007" />
+      <option name="presentableId" value="LOCAL-00007" />
+      <option name="project" value="LOCAL" />
+      <updated>1745269898085</updated>
+    </task>
+    <option name="localTasksCounter" value="8" />
     <servers />
   </component>
   <component name="Vcs.Log.Tabs.Properties">
@@ -243,7 +243,8 @@
     <MESSAGE value="feat: добавлено консольное обновление задач + вызов истории (Main)" />
     <MESSAGE value=" fix:  InMemoryHistoryManager исправлен метод copyTask()&#10; fix:  InMemoryTaskManager добавлены проверки на null в методах getTaskById" />
     <MESSAGE value="d" />
-    <option name="LAST_COMMIT_MESSAGE" value="d" />
+    <MESSAGE value="&#10;добавить в классе InMemoryHistoryManager реализацию нового вложенного класса  HistoryManagerLinkList&#10;&#10;изменить метод хранения истории задач с помощью двусвязного списка и HashMap&#10;&#10;убрать ограничения в количестве сохраняемых задач в истории.&#10;&#10;реализовать метод linkLast добавляющий задачу в конец списка.&#10;&#10;реализовать метод removeNode  удаляющий узел из двусязного списка задач.&#10;&#10;переименовать метод updateHistory в метод  add  и переделать логику согласно ТЗ_6.&#10;&#10;избавиться от повторных просмотров в истории.&#10;&#10;добавить метод remove для удаления задач из истории по ID &#10;&#10;добавить новый Node - отвечающий за узлы в двусвязном списке.&#10;&#10;обновить unit-тесты.&#10;&#10;реализовать пользовательский сценарий в Main. &#10;&#10;добавить Javadoc в  InMemoryHistoryManager" />
+    <option name="LAST_COMMIT_MESSAGE" value="&#10;добавить в классе InMemoryHistoryManager реализацию нового вложенного класса  HistoryManagerLinkList&#10;&#10;изменить метод хранения истории задач с помощью двусвязного списка и HashMap&#10;&#10;убрать ограничения в количестве сохраняемых задач в истории.&#10;&#10;реализовать метод linkLast добавляющий задачу в конец списка.&#10;&#10;реализовать метод removeNode  удаляющий узел из двусязного списка задач.&#10;&#10;переименовать метод updateHistory в метод  add  и переделать логику согласно ТЗ_6.&#10;&#10;избавиться от повторных просмотров в истории.&#10;&#10;добавить метод remove для удаления задач из истории по ID &#10;&#10;добавить новый Node - отвечающий за узлы в двусвязном списке.&#10;&#10;обновить unit-тесты.&#10;&#10;реализовать пользовательский сценарий в Main. &#10;&#10;добавить Javadoc в  InMemoryHistoryManager" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/src/Main.java
+++ b/src/Main.java
@@ -149,36 +149,36 @@ public class Main {
                     System.out.println("Запуск сценария ТЗ_6");
                     addPreloadedTasks(manager); // загружены предустановленные задачи
                     /////////////////////////////////////////////
-                    System.out.println("Запрашиваем задачу №2 :"  + manager.getTaskById(2) );
-                    System.out.println("Запрашиваем задачу №1 :"  + manager.getTaskById(1) );
-                    System.out.println("Запрашиваем подзадачу №7 :"  + manager.getSubtaskById(7) );
-                    System.out.println("Запрашиваем подзадачу №4 :"  + manager.getSubtaskById(4) );
-                    System.out.println("Запрашиваем эпик №10 :"  + manager.getEpicById(10) );
+                    System.out.println("Запрашиваем задачу №2 :" + manager.getTaskById(2));
+                    System.out.println("Запрашиваем задачу №1 :" + manager.getTaskById(1));
+                    System.out.println("Запрашиваем подзадачу №7 :" + manager.getSubtaskById(7));
+                    System.out.println("Запрашиваем подзадачу №4 :" + manager.getSubtaskById(4));
+                    System.out.println("Запрашиваем эпик №10 :" + manager.getEpicById(10));
                     printHistory(manager);
 
-                    System.out.println("Запрашиваем задачу №2 :"  + manager.getTaskById(2) );
+                    System.out.println("Запрашиваем задачу №2 :" + manager.getTaskById(2));
                     printHistory(manager);
 
-                    System.out.println("Запрашиваем задачу №1 :"  + manager.getTaskById(1) );
-                    System.out.println("Запрашиваем эпик №10 :"  + manager.getEpicById(10) );
-                    System.out.println("Запрашиваем эпик №3 :"  + manager.getEpicById(3) );
-                    System.out.println("Запрашиваем подзадачу №7 :"  + manager.getSubtaskById(7) );
+                    System.out.println("Запрашиваем задачу №1 :" + manager.getTaskById(1));
+                    System.out.println("Запрашиваем эпик №10 :" + manager.getEpicById(10));
+                    System.out.println("Запрашиваем эпик №3 :" + manager.getEpicById(3));
+                    System.out.println("Запрашиваем подзадачу №7 :" + manager.getSubtaskById(7));
                     printHistory(manager);
 
 
-                    System.out.println("Удаляем задачу №1 :"    );
+                    System.out.println("Удаляем задачу №1 :");
                     manager.removeTaskById(1);
                     printHistory(manager);
 
-                    System.out.println("Запрашиваем подзадачу №5 :"  + manager.getSubtaskById(5) );
-                    System.out.println("Запрашиваем эпик №6 :"  + manager.getEpicById(6) );
-                    System.out.println("Запрашиваем подзадачу №7 :"  + manager.getSubtaskById(7) );
-                    System.out.println("Запрашиваем подзадачу №9 :"  + manager.getSubtaskById(9) );
-                    System.out.println("Запрашиваем подзадачу №8 :"  + manager.getSubtaskById(8) );
+                    System.out.println("Запрашиваем подзадачу №5 :" + manager.getSubtaskById(5));
+                    System.out.println("Запрашиваем эпик №6 :" + manager.getEpicById(6));
+                    System.out.println("Запрашиваем подзадачу №7 :" + manager.getSubtaskById(7));
+                    System.out.println("Запрашиваем подзадачу №9 :" + manager.getSubtaskById(9));
+                    System.out.println("Запрашиваем подзадачу №8 :" + manager.getSubtaskById(8));
                     printHistory(manager);
 
-                    System.out.println("Запрашиваем задачу №2 :"  + manager.getTaskById(2) );
-                    System.out.println("Удаляем эпик №6 и его подзадачи:"    );
+                    System.out.println("Запрашиваем задачу №2 :" + manager.getTaskById(2));
+                    System.out.println("Удаляем эпик №6 и его подзадачи:");
                     manager.removeTaskById(6);
                     printHistory(manager);
 
@@ -295,8 +295,8 @@ public class Main {
                     System.out.println("   Подзадачи:");
 
                     for (Integer subtaskId : subtaskIds) {
-                         //Subtask subtask = manager.getSubtaskById(subtaskId); - наполняет историю подзадачаими.
-                         Subtask subtask =  manager.getSubtasksMap().get(subtaskId); //изменен вывод через новый геттер.
+                        //Subtask subtask = manager.getSubtaskById(subtaskId); - наполняет историю подзадачаими.
+                        Subtask subtask = manager.getSubtasksMap().get(subtaskId); //изменен вывод через новый геттер.
                         if (subtask != null) {
                             System.out.println("   ↳ " + subtask);
                         } else {
@@ -348,7 +348,7 @@ public class Main {
     public static void printHistory(TaskManager manager) {
         System.out.println("Печать истории:");
 
-        if(manager.getHistory().isEmpty()) {
+        if (manager.getHistory().isEmpty()) {
             System.out.println("История пустая.");
         }
 

--- a/src/Main.java
+++ b/src/Main.java
@@ -142,8 +142,46 @@ public class Main {
 
 
                 case "10":
-                    System.out.println("Печать истории");
                     printHistory(manager);
+                    break;
+
+                case "11":
+                    System.out.println("Запуск сценария ТЗ_6");
+                    addPreloadedTasks(manager); // загружены предустановленные задачи
+                    /////////////////////////////////////////////
+                    System.out.println("Запрашиваем задачу №2 :"  + manager.getTaskById(2) );
+                    System.out.println("Запрашиваем задачу №1 :"  + manager.getTaskById(1) );
+                    System.out.println("Запрашиваем подзадачу №7 :"  + manager.getSubtaskById(7) );
+                    System.out.println("Запрашиваем подзадачу №4 :"  + manager.getSubtaskById(4) );
+                    System.out.println("Запрашиваем эпик №10 :"  + manager.getEpicById(10) );
+                    printHistory(manager);
+
+                    System.out.println("Запрашиваем задачу №2 :"  + manager.getTaskById(2) );
+                    printHistory(manager);
+
+                    System.out.println("Запрашиваем задачу №1 :"  + manager.getTaskById(1) );
+                    System.out.println("Запрашиваем эпик №10 :"  + manager.getEpicById(10) );
+                    System.out.println("Запрашиваем эпик №3 :"  + manager.getEpicById(3) );
+                    System.out.println("Запрашиваем подзадачу №7 :"  + manager.getSubtaskById(7) );
+                    printHistory(manager);
+
+
+                    System.out.println("Удаляем задачу №1 :"    );
+                    manager.removeTaskById(1);
+                    printHistory(manager);
+
+                    System.out.println("Запрашиваем подзадачу №5 :"  + manager.getSubtaskById(5) );
+                    System.out.println("Запрашиваем эпик №6 :"  + manager.getEpicById(6) );
+                    System.out.println("Запрашиваем подзадачу №7 :"  + manager.getSubtaskById(7) );
+                    System.out.println("Запрашиваем подзадачу №9 :"  + manager.getSubtaskById(9) );
+                    System.out.println("Запрашиваем подзадачу №8 :"  + manager.getSubtaskById(8) );
+                    printHistory(manager);
+
+                    System.out.println("Запрашиваем задачу №2 :"  + manager.getTaskById(2) );
+                    System.out.println("Удаляем эпик №6 и его подзадачи:"    );
+                    manager.removeTaskById(6);
+                    printHistory(manager);
+
                     break;
 
                 case "0":
@@ -170,6 +208,7 @@ public class Main {
         System.out.println("8. Получение списка всех подзадач определённого эпика. по epicID");
         System.out.println("9. Загрузить предустановленные задачи");
         System.out.println("10. Печать истории");
+        System.out.println("11. Запустить сценарий ТЗ_6");
         System.out.println("0. ВЫХОД");
     }
 
@@ -255,10 +294,9 @@ public class Main {
                 if (!subtaskIds.isEmpty()) {
                     System.out.println("   Подзадачи:");
 
-
                     for (Integer subtaskId : subtaskIds) {
-                        Subtask subtask = manager.getSubtaskById(subtaskId);
-                        //Subtask subtask = subtasks.get(subtaskId);
+                         //Subtask subtask = manager.getSubtaskById(subtaskId); - наполняет историю подзадачаими.
+                         Subtask subtask =  manager.getSubtasksMap().get(subtaskId); //изменен вывод через новый геттер.
                         if (subtask != null) {
                             System.out.println("   ↳ " + subtask);
                         } else {
@@ -275,32 +313,44 @@ public class Main {
 
 
     public static void addPreloadedTasks(TaskManager manager) {
-        Task task1 = new Task("Сходить в магазин", "Купить продукты на неделю.", TaskStatus.NEW);
+        Task task1 = new Task("Задача_1", "Описание Задачи_1", TaskStatus.NEW);
         manager.addTask(task1);
-        Task task2 = new Task("Обед", "Заказать еду через приложение", TaskStatus.IN_PROGRESS);
+        Task task2 = new Task("Задача_2", "Описание Задачи_2", TaskStatus.IN_PROGRESS);
         manager.addTask(task2);
 
-        Epic epic1 = new Epic("Поездка в Сочи", "Поездка в Сочи на горнолыжку");
+        Epic epic1 = new Epic("Эпик_1", "Описание Эпика_1");
         manager.addEpic(epic1);
-        Subtask subtask1 = new Subtask("Билеты на самолет", "Купить билеты в Сочи",
+        Subtask subtask1 = new Subtask("Подзадача_1", "Описание Подзадачи_1",
                 TaskStatus.NEW, epic1.getTaskID());
         manager.addSubtask(subtask1);
-        Subtask subtask2 = new Subtask("Отель в Сочи", "Выбрать подходящий отель и забронировать его",
+        Subtask subtask2 = new Subtask("Подзадача_2", "Описание Подзадачи_2",
                 TaskStatus.IN_PROGRESS, epic1.getTaskID());
         manager.addSubtask(subtask2);
 
-        Epic epic2 = new Epic("Обновление компьютера", "Заменить комплектующие пк");
+        Epic epic2 = new Epic("Эпик_2", "Описание Эпика_2");
         manager.addEpic(epic2);
-        Subtask subtask3 = new Subtask("купить видеокарту", "выбрать подходящую вк из серии 50..",
+        Subtask subtask3 = new Subtask("Подзадача_3", "Описание Подзадачи_3",
                 TaskStatus.NEW, epic2.getTaskID());
         manager.addSubtask(subtask3);
-        Subtask subtask4 = new Subtask("купить Блок Питания", "подобрать БП от 1200 Вт",
+        Subtask subtask4 = new Subtask("Подзадача_4", "Описание Подзадачи_4",
                 TaskStatus.IN_PROGRESS, epic2.getTaskID());
         manager.addSubtask(subtask4);
+        Subtask subtask5 = new Subtask("Подзадача_5", "Описание Подзадачи_5",
+                TaskStatus.DONE, epic2.getTaskID());
+        manager.addSubtask(subtask5);
+
+        Epic epic3 = new Epic("Эпик_3", "Описание Эпика_3");
+        manager.addEpic(epic3);
+
 
     }
 
     public static void printHistory(TaskManager manager) {
+        System.out.println("Печать истории:");
+
+        if(manager.getHistory().isEmpty()) {
+            System.out.println("История пустая.");
+        }
 
         for (Task task : manager.getHistory()) {
             System.out.println(task);

--- a/src/controllers/HistoryManager.java
+++ b/src/controllers/HistoryManager.java
@@ -6,9 +6,10 @@ import java.util.List;
 
 public interface HistoryManager {
 
-    void updateHistory(Task task);
+    void add(Task task);
 
-    List<Task>  getHistory();
+    List<Task> getHistory();
 
+    void remove(int id);
 
 }

--- a/src/controllers/InMemoryHistoryManager.java
+++ b/src/controllers/InMemoryHistoryManager.java
@@ -17,14 +17,14 @@ import java.util.List;
 
 public class InMemoryHistoryManager implements HistoryManager {
 
-    private HashMap<Integer, Node<Task>> historyMap = new HashMap<>();
-    private Node<Task> head;
-    private Node<Task> tail;
+    private HashMap<Integer, Node> historyMap = new HashMap<>();
+    private Node head;
+    private Node tail;
 
 
     private void linkLast(Task task) {
-        final Node<Task> oldTail = tail;
-        final Node<Task> newNode = new Node<>(tail, task, null);
+        final Node oldTail = tail;
+        final Node newNode = new Node(tail, task, null);
         tail = newNode;
         if (oldTail == null)
             this.head = newNode;
@@ -35,7 +35,7 @@ public class InMemoryHistoryManager implements HistoryManager {
 
     private List<Task> getTasks() {
         List<Task> result = new ArrayList<>(historyMap.size());
-        Node<Task> current = head;
+        Node current = head;
         while (current != null) {
             result.add(current.getData());
             current = current.getNext();
@@ -43,10 +43,10 @@ public class InMemoryHistoryManager implements HistoryManager {
         return result;
     }
 
-    private void removeNode(Node<Task> node) {
+    private void removeNode(Node node) {
         if (node == null) return;
-        Node<Task> prev = node.getPrev();
-        Node<Task> next = node.getNext();
+        Node prev = node.getPrev();
+        Node next = node.getNext();
 
         if (prev == null) {
             head = next;
@@ -73,7 +73,7 @@ public class InMemoryHistoryManager implements HistoryManager {
 
         remove(id);
         linkLast(taskCopy);
-        Node<Task> newNode = tail;
+        Node newNode = tail;
         historyMap.put(id, newNode);
     }
 
@@ -85,7 +85,7 @@ public class InMemoryHistoryManager implements HistoryManager {
     @Override
     public void remove(int id) {
         if (historyMap.containsKey(id)) {
-            Node<Task> node = historyMap.get(id);
+            Node node = historyMap.get(id);
             removeNode(node);
             historyMap.remove(id);
         }

--- a/src/controllers/InMemoryHistoryManager.java
+++ b/src/controllers/InMemoryHistoryManager.java
@@ -26,14 +26,14 @@ public class InMemoryHistoryManager implements HistoryManager {
      * Хранит ссылки на первый ({@code head}) и последний ({@code tail}) элементы списка,
      * а также текущий размер списка ({@code size}).
      */
-    private class HistoryManagerLinkList<Task> {
-        private Node<Task> head;
-        private Node<Task> tail;
+    private class HistoryManagerLinkList<T> {
+        private Node<T> head;
+        private Node<T> tail;
         private int size = 0;
 
-        public void linkLast(Task task) {
-            final Node<Task> oldTail = tail;
-            final Node<Task> newNode = new Node<>(tail, task, null);
+        public void linkLast(T task) {
+            final Node<T> oldTail = tail;
+            final Node<T> newNode = new Node<>(tail, task, null);
             tail = newNode;
             if (oldTail == null)
                 this.head = newNode;
@@ -43,9 +43,9 @@ public class InMemoryHistoryManager implements HistoryManager {
             this.size++;
         }
 
-        public List<Task> getTasks() {
-            List<Task> result = new ArrayList<>(size);
-            Node<Task> current = head;
+        public List<T> getTasks() {
+            List<T> result = new ArrayList<>(size);
+            Node<T> current = head;
             while (current != null) {
                 result.add(current.getData());
                 current = current.getNext();
@@ -53,11 +53,11 @@ public class InMemoryHistoryManager implements HistoryManager {
             return result;
         }
 
-        public Node<Task> getHead() {
+        public Node<T> getHead() {
             return head;
         }
 
-        public Node<Task> getTail() {
+        public Node<T> getTail() {
             return tail;
         }
 
@@ -65,11 +65,11 @@ public class InMemoryHistoryManager implements HistoryManager {
             return size;
         }
 
-        private void setHead(Node<Task> head) {
+        private void setHead(Node<T> head) {
             this.head = head;
         }
 
-        private void setTail(Node<Task> tail) {
+        private void setTail(Node<T> tail) {
             this.tail = tail;
         }
 

--- a/src/controllers/InMemoryHistoryManager.java
+++ b/src/controllers/InMemoryHistoryManager.java
@@ -18,88 +18,46 @@ import java.util.List;
 public class InMemoryHistoryManager implements HistoryManager {
 
     private HashMap<Integer, Node<Task>> historyMap = new HashMap<>();
-    private final HistoryManagerLinkList<Task> historyLinkList = new HistoryManagerLinkList<>();
+    private Node<Task> head;
+    private Node<Task> tail;
 
 
-    /**
-     * Вложенный класс для управления двусвязным списком задач.
-     * Хранит ссылки на первый ({@code head}) и последний ({@code tail}) элементы списка,
-     * а также текущий размер списка ({@code size}).
-     */
-    private class HistoryManagerLinkList<T> {
-        private Node<T> head;
-        private Node<T> tail;
-        private int size = 0;
-
-        public void linkLast(T task) {
-            final Node<T> oldTail = tail;
-            final Node<T> newNode = new Node<>(tail, task, null);
-            tail = newNode;
-            if (oldTail == null)
-                this.head = newNode;
-            else {
-                oldTail.setNext(newNode);
-            }
-            this.size++;
-        }
-
-        public List<T> getTasks() {
-            List<T> result = new ArrayList<>(size);
-            Node<T> current = head;
-            while (current != null) {
-                result.add(current.getData());
-                current = current.getNext();
-            }
-            return result;
-        }
-
-        public Node<T> getHead() {
-            return head;
-        }
-
-        public Node<T> getTail() {
-            return tail;
-        }
-
-        public int getSize() {
-            return size;
-        }
-
-        private void setHead(Node<T> head) {
-            this.head = head;
-        }
-
-        private void setTail(Node<T> tail) {
-            this.tail = tail;
-        }
-
-        private void setSize(int size) {
-            this.size = size;
+    private void linkLast(Task task) {
+        final Node<Task> oldTail = tail;
+        final Node<Task> newNode = new Node<>(tail, task, null);
+        tail = newNode;
+        if (oldTail == null)
+            this.head = newNode;
+        else {
+            oldTail.setNext(newNode);
         }
     }
 
-    /**
-     * Удаляет узел из двусвязного списка.
-     * Обновляет ссылки соседних узлов ({@code prev} и {@code next}).
-     *
-     * @param node Узел для удаления. Если {@code null}, метод завершается без изменений.
-     */
+    private List<Task> getTasks() {
+        List<Task> result = new ArrayList<>(historyMap.size());
+        Node<Task> current = head;
+        while (current != null) {
+            result.add(current.getData());
+            current = current.getNext();
+        }
+        return result;
+    }
+
     private void removeNode(Node<Task> node) {
         if (node == null) return;
         Node<Task> prev = node.getPrev();
         Node<Task> next = node.getNext();
 
         if (prev == null) {
-            historyLinkList.setHead(next);
+            head = next;
         } else {
             prev.setNext(next);
         }
         if (next == null) {
-            historyLinkList.setTail(prev);
+            tail = prev;
         } else {
             next.setPrev(prev);
         }
-        historyLinkList.setSize(historyLinkList.getSize() - 1);
     }
 
     /**
@@ -108,23 +66,20 @@ public class InMemoryHistoryManager implements HistoryManager {
      *
      * @param task Задача для добавления. Не может быть {@code null}.
      */
-
     @Override
     public void add(Task task) {
         Task taskCopy = copyTask(task);
         int id = taskCopy.getTaskID();
 
         remove(id);
-
-        historyLinkList.linkLast(taskCopy);
-        Node<Task> newNode = historyLinkList.getTail();
+        linkLast(taskCopy);
+        Node<Task> newNode = tail;
         historyMap.put(id, newNode);
-
     }
 
     @Override
     public List<Task> getHistory() {
-        return historyLinkList.getTasks();
+        return getTasks();
     }
 
     @Override
@@ -142,7 +97,6 @@ public class InMemoryHistoryManager implements HistoryManager {
      * @param task Исходная задача для копирования.
      * @return Копия задачи.
      */
-
     private Task copyTask(Task task) {
         TaskType type = task.getType();
         if (type == TaskType.EPIC) {
@@ -168,6 +122,4 @@ public class InMemoryHistoryManager implements HistoryManager {
             return copyTask;
         }
     }
-
-
 }

--- a/src/controllers/InMemoryTaskManager.java
+++ b/src/controllers/InMemoryTaskManager.java
@@ -55,7 +55,7 @@ public class InMemoryTaskManager implements TaskManager {
 
     @Override
     public HashMap<Integer, Subtask> getSubtasksMap() {
-        HashMap<Integer, Subtask> subtasksMap  = new HashMap<>(subtasks);
+        HashMap<Integer, Subtask> subtasksMap = new HashMap<>(subtasks);
         return subtasksMap;
     }
 
@@ -84,7 +84,7 @@ public class InMemoryTaskManager implements TaskManager {
     @Override
     public Task getTaskById(int taskId) {
         Task task = tasks.get(taskId);
-        if(task != null) {
+        if (task != null) {
             historyManager.add(task);
         }
         return task;
@@ -104,7 +104,7 @@ public class InMemoryTaskManager implements TaskManager {
     @Override
     public Subtask getSubtaskById(int taskId) {
         Subtask subtask = subtasks.get(taskId);
-        if(subtask != null) {
+        if (subtask != null) {
             historyManager.add(subtask);
         }
         return subtask;
@@ -134,11 +134,11 @@ public class InMemoryTaskManager implements TaskManager {
     public int addSubtask(Subtask newSubtask) {
         final int id = generateId();
         newSubtask.setTaskID(id);
-        if(!(epics.containsKey(newSubtask.getEpicID()))){
+        if (!(epics.containsKey(newSubtask.getEpicID()))) {
             return -3; // Ошибка эпика с таким EpicID не существует.
         }
 
-        if(newSubtask.getEpicID() == newSubtask.getTaskID()){
+        if (newSubtask.getEpicID() == newSubtask.getTaskID()) {
             return -2;  //ошибка подзадача не может стать своим эпиком.
         }
         subtasks.put(id, newSubtask);

--- a/src/controllers/InMemoryTaskManager.java
+++ b/src/controllers/InMemoryTaskManager.java
@@ -6,9 +6,7 @@ import model.Task;
 import util.TaskStatus;
 import util.TaskType;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.*;
 
 public class InMemoryTaskManager implements TaskManager {
     private HashMap<Integer, Task> tasks = new HashMap<>();
@@ -64,9 +62,18 @@ public class InMemoryTaskManager implements TaskManager {
     public void removeAllTasks(TaskType type) {
         switch (type) {
             case TASK:
+                Set<Integer> tasksIdSet = tasks.keySet();
+                for (Integer id : tasksIdSet) {
+                    historyManager.remove(id);
+                }
                 tasks.clear();
                 break;
             case EPIC:
+                Set<Integer> idsSet = new HashSet<>(subtasks.keySet());
+                idsSet.addAll(epics.keySet());
+                for (Integer id : idsSet) {
+                    historyManager.remove(id);
+                }
                 subtasks.clear();
                 epics.clear();
                 break;
@@ -74,6 +81,10 @@ public class InMemoryTaskManager implements TaskManager {
                 for (Epic epic : epics.values()) {
                     epic.clearSubtaskIdList();
                     updEpicStatus(epic);
+                }
+                Set<Integer> subtasksIdSet = subtasks.keySet();
+                for (Integer id : subtasksIdSet) {
+                    historyManager.remove(id);
                 }
                 subtasks.clear();
                 break;
@@ -84,30 +95,36 @@ public class InMemoryTaskManager implements TaskManager {
     @Override
     public Task getTaskById(int taskId) {
         Task task = tasks.get(taskId);
-        if (task != null) {
-            historyManager.add(task);
+        if (task == null) {
+            return null;
         }
-        return task;
+        historyManager.add(task);
+        Task copyTask = new Task(task);
+        return copyTask;
     }
 
     //c. Получение по идентификатору.
     @Override
     public Epic getEpicById(int taskId) {
         Epic epic = epics.get(taskId);
-        if (epic != null) {
-            historyManager.add(epic);
+        if (epic == null) {
+            return null;
         }
-        return epic;
+        historyManager.add(epic);
+        Epic copyEpic = new Epic(epic);
+        return copyEpic;
     }
 
     //c. Получение по идентификатору.
     @Override
     public Subtask getSubtaskById(int taskId) {
         Subtask subtask = subtasks.get(taskId);
-        if (subtask != null) {
-            historyManager.add(subtask);
+        if (subtask == null) {
+            return null;
         }
-        return subtask;
+        historyManager.add(subtask);
+        Subtask copySubtask = new Subtask(subtask);
+        return copySubtask;
     }
 
 
@@ -251,6 +268,5 @@ public class InMemoryTaskManager implements TaskManager {
         }
         epic.setStatus(result);
     }
-
 
 }

--- a/src/controllers/InMemoryTaskManager.java
+++ b/src/controllers/InMemoryTaskManager.java
@@ -21,7 +21,6 @@ public class InMemoryTaskManager implements TaskManager {
         this.historyManager = historyManager;
     }
 
-
     @Override
     public List<Task> getHistory() {
         return historyManager.getHistory();
@@ -36,22 +35,28 @@ public class InMemoryTaskManager implements TaskManager {
     // a. Получение списка всех задач. Task
     @Override
     public ArrayList<Task> getTasks() {
-        ArrayList<Task> tasksList = new ArrayList<>(tasks.values());  // нужно ли добавлять в хистори?
+        ArrayList<Task> tasksList = new ArrayList<>(tasks.values());
         return tasksList;
     }
 
     // a. Получение списка всех задач. Epic
     @Override
     public ArrayList<Epic> getEpics() {
-        ArrayList<Epic> epicsList = new ArrayList<>(epics.values()); // нужно ли добавлять в хистори?
+        ArrayList<Epic> epicsList = new ArrayList<>(epics.values());
         return epicsList;
     }
 
     // a. Получение списка всех задач. Subtask
     @Override
     public ArrayList<Subtask> getSubtasks() {
-        ArrayList<Subtask> subtasksList = new ArrayList<>(subtasks.values());  // нужно ли добавлять в хистори?
+        ArrayList<Subtask> subtasksList = new ArrayList<>(subtasks.values());
         return subtasksList;
+    }
+
+    @Override
+    public HashMap<Integer, Subtask> getSubtasksMap() {
+        HashMap<Integer, Subtask> subtasksMap  = new HashMap<>(subtasks);
+        return subtasksMap;
     }
 
     //b. Удаление всех задач.
@@ -80,7 +85,7 @@ public class InMemoryTaskManager implements TaskManager {
     public Task getTaskById(int taskId) {
         Task task = tasks.get(taskId);
         if(task != null) {
-            historyManager.updateHistory(task);
+            historyManager.add(task);
         }
         return task;
     }
@@ -90,7 +95,7 @@ public class InMemoryTaskManager implements TaskManager {
     public Epic getEpicById(int taskId) {
         Epic epic = epics.get(taskId);
         if (epic != null) {
-            historyManager.updateHistory(epic);
+            historyManager.add(epic);
         }
         return epic;
     }
@@ -100,7 +105,7 @@ public class InMemoryTaskManager implements TaskManager {
     public Subtask getSubtaskById(int taskId) {
         Subtask subtask = subtasks.get(taskId);
         if(subtask != null) {
-            historyManager.updateHistory(subtask);
+            historyManager.add(subtask);
         }
         return subtask;
     }
@@ -174,12 +179,14 @@ public class InMemoryTaskManager implements TaskManager {
     public void removeTaskById(int taskId) {
         if (tasks.containsKey(taskId)) {
             tasks.remove(taskId);
+            historyManager.remove(taskId);
             return;
         }
 
         if (subtasks.containsKey(taskId)) {
             int epicId = subtasks.get(taskId).getEpicID();
             subtasks.remove(taskId);
+            historyManager.remove(taskId);
             Epic epic = epics.get(epicId);
 
             if (epic != null) {
@@ -194,8 +201,10 @@ public class InMemoryTaskManager implements TaskManager {
             ArrayList<Integer> subtaskIdList = new ArrayList<>(epic.getSubtaskIdList()); // получаем ID подзадач Эпика
             for (Integer subtaskId : subtaskIdList) {
                 subtasks.remove(subtaskId);
+                historyManager.remove(subtaskId);
             }
             epics.remove(taskId);
+            historyManager.remove(taskId);
         }
     }
 

--- a/src/controllers/Node.java
+++ b/src/controllers/Node.java
@@ -2,13 +2,13 @@ package controllers;
 
 import java.util.Objects;
 
-class Node<T> {
+class Node<Task> {
 
-    private T data;
-    private Node<T> next;
-    private Node<T> prev;
+    private Task data;
+    private Node<Task> next;
+    private Node<Task> prev;
 
-    public Node(Node<T> prev, T data, Node<T> next) {
+    public Node(Node<Task> prev, Task data, Node<Task> next) {
         this.data = data;
         this.next = next;
         this.prev = prev;
@@ -27,27 +27,23 @@ class Node<T> {
         return Objects.hash(data, next, prev);
     }
 
-    public T getData() {
+    public Task getData() {
         return data;
     }
 
-    public void setData(T data) {
-        this.data = data;
-    }
-
-    public Node<T> getNext() {
+    public Node<Task> getNext() {
         return next;
     }
 
-    public void setNext(Node<T> next) {
-        this.next = next;
-    }
-
-    public Node<T> getPrev() {
+    public Node<Task> getPrev() {
         return prev;
     }
 
-    public void setPrev(Node<T> prev) {
+    void setNext(Node<Task> next) {
+        this.next = next;
+    }
+
+    void setPrev(Node<Task> prev) {
         this.prev = prev;
     }
 }

--- a/src/controllers/Node.java
+++ b/src/controllers/Node.java
@@ -1,14 +1,16 @@
 package controllers;
 
+import model.Task;
+
 import java.util.Objects;
 
-class Node<Task> {
+class Node {
 
     private Task data;
-    private Node<Task> next;
-    private Node<Task> prev;
+    private Node next;
+    private Node prev;
 
-    public Node(Node<Task> prev, Task data, Node<Task> next) {
+    public Node(Node prev, Task data, Node next) {
         this.data = data;
         this.next = next;
         this.prev = prev;
@@ -18,8 +20,10 @@ class Node<Task> {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Node<?> node = (Node<?>) o;
-        return Objects.equals(data, node.data) && Objects.equals(next, node.next) && Objects.equals(prev, node.prev);
+        Node node = (Node) o;
+        return Objects.equals(data, node.data)
+                && Objects.equals(next, node.next)
+                && Objects.equals(prev, node.prev);
     }
 
     @Override
@@ -31,19 +35,20 @@ class Node<Task> {
         return data;
     }
 
-    public Node<Task> getNext() {
+    public Node getNext() {
         return next;
     }
 
-    public Node<Task> getPrev() {
+    public Node getPrev() {
         return prev;
     }
 
-    void setNext(Node<Task> next) {
+    void setNext(Node next) {
         this.next = next;
     }
 
-    void setPrev(Node<Task> prev) {
+    void setPrev(Node prev) {
         this.prev = prev;
     }
+
 }

--- a/src/controllers/Node.java
+++ b/src/controllers/Node.java
@@ -1,0 +1,53 @@
+package controllers;
+
+import java.util.Objects;
+
+class Node <T> {
+
+    private T data;
+    private Node<T> next;
+    private Node<T> prev;
+
+    public Node(Node <T> prev, T data, Node <T> next) {
+        this.data = data;
+        this.next = next;
+        this.prev = prev;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Node<?> node = (Node<?>) o;
+        return Objects.equals(data, node.data) && Objects.equals(next, node.next) && Objects.equals(prev, node.prev);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, next, prev);
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+
+    public Node<T> getNext() {
+        return next;
+    }
+
+    public void setNext(Node<T> next) {
+        this.next = next;
+    }
+
+    public Node<T> getPrev() {
+        return prev;
+    }
+
+    public void setPrev(Node<T> prev) {
+        this.prev = prev;
+    }
+}

--- a/src/controllers/Node.java
+++ b/src/controllers/Node.java
@@ -2,13 +2,13 @@ package controllers;
 
 import java.util.Objects;
 
-class Node <T> {
+class Node<T> {
 
     private T data;
     private Node<T> next;
     private Node<T> prev;
 
-    public Node(Node <T> prev, T data, Node <T> next) {
+    public Node(Node<T> prev, T data, Node<T> next) {
         this.data = data;
         this.next = next;
         this.prev = prev;

--- a/src/controllers/TaskManager.java
+++ b/src/controllers/TaskManager.java
@@ -6,6 +6,7 @@ import model.Task;
 import util.TaskType;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public interface TaskManager {
@@ -62,4 +63,6 @@ public interface TaskManager {
 
     //b. Для эпиков: Управление статусами
     void updEpicStatus(Epic epic);
+
+    HashMap<Integer,Subtask> getSubtasksMap();
 }

--- a/src/controllers/TaskManager.java
+++ b/src/controllers/TaskManager.java
@@ -64,5 +64,5 @@ public interface TaskManager {
     //b. Для эпиков: Управление статусами
     void updEpicStatus(Epic epic);
 
-    HashMap<Integer,Subtask> getSubtasksMap();
+    HashMap<Integer, Subtask> getSubtasksMap();
 }

--- a/src/model/Epic.java
+++ b/src/model/Epic.java
@@ -36,7 +36,8 @@ public class Epic extends model.Task {
     public void removeSubtaskId(int subtaskId) {
         this.subtaskIdList.remove(Integer.valueOf(subtaskId));
     }
-    public void clearSubtaskIdList () {
+
+    public void clearSubtaskIdList() {
         this.subtaskIdList.clear();
     }
 

--- a/src/model/Epic.java
+++ b/src/model/Epic.java
@@ -14,13 +14,26 @@ public class Epic extends model.Task {
         this.taskType = TaskType.EPIC;
     }
 
+
+    public Epic(Epic other) {
+        super(other);
+        this.subtaskIdList = new ArrayList<>(other.getSubtaskIdList());
+        this.taskType = TaskType.EPIC;
+    }
+
+
     public void setSubtaskIdList(int subtaskId) {
         if (subtaskId == this.getTaskID()) {
+            return;
+        }
+        // проверка на дубликат айди в списке подзадач.
+        if (this.subtaskIdList.contains(subtaskId)) {
             return;
         }
         if (this.subtaskIdList == null) {
             this.subtaskIdList = new ArrayList<>();
         }
+
         this.subtaskIdList.add(subtaskId);
     }
 

--- a/src/model/Subtask.java
+++ b/src/model/Subtask.java
@@ -12,10 +12,16 @@ public class Subtask extends model.Task {
         this.taskType = TaskType.SUBTASK;
     }
 
+    public Subtask(Subtask other) {
+        super(other);
+        this.epicID = other.epicID;
+        this.taskType = TaskType.SUBTASK;
+    }
+
+
     public int getEpicID() {
         return epicID;
     }
-
 
     @Override
     public TaskType getType() {

--- a/src/model/Task.java
+++ b/src/model/Task.java
@@ -21,11 +21,20 @@ public class Task {
         this.taskType = TaskType.TASK;
     }
 
+    //конструктор для копирования задач
+    public Task(Task other) {
+        this.name = other.name;
+        this.description = other.description;
+        this.status = other.status;
+        this.taskType = other.taskType;
+        this.taskID = other.taskID;
+
+    }
+
 
     public TaskType getType() {
         return TaskType.TASK;
     }
-
 
     public void setTaskID(int taskID) {
         this.taskID = taskID;

--- a/src/model/Task.java
+++ b/src/model/Task.java
@@ -2,6 +2,7 @@ package model;
 
 import util.TaskStatus;
 import util.TaskType;
+
 import java.util.Objects;
 
 public class Task {
@@ -24,7 +25,6 @@ public class Task {
     public TaskType getType() {
         return TaskType.TASK;
     }
-
 
 
     public void setTaskID(int taskID) {
@@ -62,7 +62,7 @@ public class Task {
     @Override
     public String toString() {
         return "[" + taskType + "]" + " [ID:" + taskID + "]" +
-                " name: " + name + " [" + status + "] "  +
+                " name: " + name + " [" + status + "] " +
                 "Description: " + description + "\n";
     }
 

--- a/test/controllers/InMemoryTaskManagerTest.java
+++ b/test/controllers/InMemoryTaskManagerTest.java
@@ -331,11 +331,9 @@ class InMemoryTaskManagerTest {
         int epicID = subtask.getEpicID();
         taskManager.removeTaskById(subTaskId);
         Epic epic = taskManager.getEpicById(epicID);
-        assertFalse(epic.getSubtaskIdList().contains(subTaskId),"Ошибка! ID не должно быть в списке" );
+        assertFalse(epic.getSubtaskIdList().contains(subTaskId), "Ошибка! ID не должно быть в списке");
 
     }
-
-
 
 
 }

--- a/test/controllers/InMemoryTaskManagerTest.java
+++ b/test/controllers/InMemoryTaskManagerTest.java
@@ -11,8 +11,8 @@ import util.TaskType;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static util.TaskStatus.IN_PROGRESS;
-import static util.TaskStatus.NEW;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static util.TaskStatus.*;
 
 class InMemoryTaskManagerTest {
 
@@ -38,9 +38,8 @@ class InMemoryTaskManagerTest {
 
     @Test
     void updateAndGetHistory() {
-
         HistoryManager historyManager = Managers.getDefaultHistory();
-        historyManager.updateHistory(task);
+        historyManager.add(task);
         final List<Task> history = historyManager.getHistory();
 
         assertNotNull(history, "История  пустая.");
@@ -50,8 +49,6 @@ class InMemoryTaskManagerTest {
 
     @Test
     void removeAllTasks() {
-        taskManager.addSubtask(subtask);
-
         taskManager.removeAllTasks(TaskType.TASK);
         assertTrue(taskManager.getTasks().isEmpty(), "Ошибка! Список Task должен быть пуст");
 
@@ -172,7 +169,6 @@ class InMemoryTaskManagerTest {
         TaskStatus epicStatus = epic.getStatus();
         taskManager.getEpicById(epicId); // получаем эпик по id и записываем его в историю
 
-
         Epic epicUpdated = new Epic("Новый Эпик", "Новое описание Эпика");
         epicUpdated.setTaskID(epicId);
         epicUpdated.setStatus(IN_PROGRESS);
@@ -209,7 +205,137 @@ class InMemoryTaskManagerTest {
 
     @Test
     void removeTaskById() {
+        Task newTask = new Task("Test Task", "Test description", NEW);
+        Subtask newSubtask = new Subtask("Test Subtask_2", "Subtask_2 description", NEW, epicId);
+        Epic newEpic = new Epic("Test Epic", "Test Epic description");
+
+        int taskIdToDel = taskManager.addTask(newTask);
+        int subTaskIdToDel = taskManager.addTask(newSubtask);
+        int epicIdToDel = taskManager.addTask(newSubtask);
+
+
+        taskManager.removeTaskById(taskIdToDel);
+        Task removedTask = taskManager.getTaskById(taskIdToDel);
+
+        taskManager.removeTaskById(subTaskIdToDel);
+        Subtask removedSubTask = taskManager.getSubtaskById(subTaskIdToDel);
+
+        taskManager.removeTaskById(epicIdToDel);
+        Epic removedEpic = taskManager.getEpicById(epicIdToDel);
+
+        assertNotEquals(newTask, removedTask, "задачи не должны совпадать");
+        assertNotEquals(newSubtask, removedSubTask, "задачи не должны совпадать");
+        assertNotEquals(newEpic, removedEpic, "задачи не должны совпадать");
     }
+
+
+    @Test
+    void updateTaskDoNotInfluenceToHistory() {
+
+        Task taskTest = new Task("Task", "Test description", NEW);
+        int taskTestId = taskManager.addTask(taskTest);
+
+        Epic epicTest = new Epic("Epic", "Test Epic description");
+        int epicTestId = taskManager.addEpic(epicTest);
+
+        Subtask subtaskTest = new Subtask("Subtask", "Test Subtask description", NEW, epicTestId);
+        int subtaskTestId = taskManager.addSubtask(subtaskTest);
+
+        Task taskToUpd = taskManager.getTaskById(taskTestId);
+        Epic epicToUpd = taskManager.getEpicById(epicTestId);
+        Subtask subtaskToUpd = taskManager.getSubtaskById(subtaskTestId);
+
+
+        taskToUpd.setName("TaskAfterUpd");
+        taskToUpd.setDescription("Task description After Upd");
+        taskToUpd.setStatus(DONE);
+
+        subtaskToUpd.setName("SubtaskAfterUpd");
+        subtaskToUpd.setDescription("Subtask description After Upd");
+        subtaskToUpd.setStatus(IN_PROGRESS);
+
+        epicToUpd.setName("EpicAfterUpd");
+        epicToUpd.setDescription("Epic description After Upd");
+
+        List<Task> history = taskManager.getHistory();
+
+        assertNotEquals(taskToUpd, history.get(0), "Задачи не должны совпадать");
+        assertNotEquals(epicToUpd, history.get(1), "Эпики не должны совпадать");
+        assertNotEquals(subtaskToUpd, history.get(2), "Подзадачи не должны совпадать");
+
+    }
+
+    @Test
+    void linkedListHistoryAddTests() {
+        int taskId = task.getTaskID();
+        int subTaskId = subtask.getTaskID();
+        int epicID = epicId;
+        List<Task> historyTest;
+
+        taskManager.getTaskById(taskId);
+        historyTest = taskManager.getHistory();
+
+
+        assertFalse(historyTest.isEmpty(), "История пуста");
+        assertNotNull(historyTest, "history = null.");
+
+        assertEquals(task, historyTest.get(0), "Задачи не совпадают");
+        assertEquals(1, historyTest.size(), "размер списка не равен 1");
+
+
+        taskManager.getSubtaskById(subTaskId);
+        historyTest = taskManager.getHistory();
+
+        assertEquals(subtask, historyTest.get(1), "Подзадачи не совпадают");
+        assertEquals(2, historyTest.size(), "размер списка не равен 2");
+
+
+        taskManager.getEpicById(epicID);
+        historyTest = taskManager.getHistory();
+
+        assertEquals(epic, historyTest.get(2), "Эпики не совпадают");
+        assertEquals(3, historyTest.size(), "размер списка не равен 3");
+
+
+        taskManager.getTaskById(taskId);
+        historyTest = taskManager.getHistory();
+
+        assertNotEquals(task, historyTest.get(0), "Ошибка! Задача не должна быть в начале списка");
+        assertEquals(task, historyTest.get(2), "Ошибка! Задача должна быть в конце списка");
+
+    }
+
+    @Test
+    void linkedListHistoryRemoveTests() {
+        int taskId = task.getTaskID();
+//        int subTaskId = subtask.getTaskID();
+//        int epicID = epicId;
+        List<Task> historyTest;
+
+        taskManager.getTaskById(taskId);
+        historyTest = taskManager.getHistory();
+
+        assertFalse(historyTest.isEmpty(), "Ошибка! История пуста");
+        assertNotNull(historyTest, "history = null.");
+
+
+        taskManager.removeTaskById(taskId);
+        historyTest = taskManager.getHistory();
+        assertTrue(historyTest.isEmpty(), "Ошибка! История НЕ пуста");
+
+    }
+
+    @Test
+    void epicSubtaskIDsListDoNotContainSubtaskIDAfterRemove() {
+        int subTaskId = subtask.getTaskID();
+        int epicID = subtask.getEpicID();
+        taskManager.removeTaskById(subTaskId);
+        Epic epic = taskManager.getEpicById(epicID);
+        assertFalse(epic.getSubtaskIdList().contains(subTaskId),"Ошибка! ID не должно быть в списке" );
+
+    }
+
+
 
 
 }

--- a/test/controllers/ManagersTest.java
+++ b/test/controllers/ManagersTest.java
@@ -2,7 +2,6 @@ package controllers;
 
 import model.Task;
 import org.junit.jupiter.api.Test;
-import util.TaskStatus;
 
 import java.util.List;
 
@@ -32,7 +31,7 @@ class ManagersTest {
         assertNotNull(historyManager, "Менеджер истории не должен быть null");
 
         Task task = new Task("Test Task", "Test Task description", NEW);
-        historyManager.updateHistory(task);
+        historyManager.add(task);
         List<Task> history = historyManager.getHistory();
 
         assertEquals(1, history.size(), "Ошибка. история должна содержать одну задачу");

--- a/test/controllers/ManagersTest.java
+++ b/test/controllers/ManagersTest.java
@@ -35,7 +35,7 @@ class ManagersTest {
         List<Task> history = historyManager.getHistory();
 
         assertEquals(1, history.size(), "Ошибка. история должна содержать одну задачу");
-        assertEquals (task,history.get(0),"Ошибка. задачи не совпадают");
+        assertEquals(task, history.get(0), "Ошибка. задачи не совпадают");
 
     }
 }

--- a/test/model/EpicTest.java
+++ b/test/model/EpicTest.java
@@ -9,7 +9,7 @@ class EpicTest {
 
 
     @Test
-    void tasksWithSameIdShouldBeEqual()  {
+    void tasksWithSameIdShouldBeEqual() {
 
         Epic epic1 = new Epic("Test Epic", "Test Epic description");
         epic1.setTaskID(1);
@@ -19,7 +19,6 @@ class EpicTest {
 
         assertEquals(epic1, epic2, "Эпики с одинаковым id должны быть равны");
     }
-
 
 
 }

--- a/test/model/SubtaskTest.java
+++ b/test/model/SubtaskTest.java
@@ -10,8 +10,9 @@ class SubtaskTest {
     @Test
     void getEpicID() {
     }
+
     @Test
-    void tasksWithSameIdShouldBeEqual()  {
+    void tasksWithSameIdShouldBeEqual() {
         Subtask subtask1 = new Subtask("Test Subtask", "Test Subtask description", NEW, 1);
         subtask1.setTaskID(1);
 

--- a/test/model/TaskTest.java
+++ b/test/model/TaskTest.java
@@ -8,7 +8,7 @@ import static util.TaskStatus.NEW;
 class TaskTest {
 
     @Test
-    void tasksWithSameIdShouldBeEqual()  {
+    void tasksWithSameIdShouldBeEqual() {
 
         Task task1 = new Task("Test Task", "Test Task description", NEW);
         task1.setTaskID(1);


### PR DESCRIPTION
… класса  HistoryManagerLinkList

изменить метод хранения истории задач с помощью двусвязного списка и HashMap

убрать ограничения в количестве сохраняемых задач в истории.

реализовать метод linkLast добавляющий задачу в конец списка.

реализовать метод removeNode  удаляющий узел из двусязного списка задач.

переименовать метод updateHistory в метод  add  и переделать логику согласно ТЗ_6.

избавиться от повторных просмотров в истории.

добавить метод remove для удаления задач из истории по ID

добавить новый Node - отвечающий за узлы в двусвязном списке.

обновить unit-тесты.

реализовать пользовательский сценарий в Main.

добавить Javadoc в  InMemoryHistoryManager